### PR TITLE
clean up smartpy script

### DIFF
--- a/pytezos-tests/pytezos_contract_tester.py
+++ b/pytezos-tests/pytezos_contract_tester.py
@@ -50,7 +50,7 @@ self_delay
     "y2s_3": merch_y2s[3],
     "y2s_4": merch_y2s[4],
     "x2": merch_x2,
-    "revocation_lock": "0x0000000000000000000000000000000000000000000000000000000000000000", 
+    "revocation_lock": "0x00", 
     "self_delay": self_delay, 
     "status": 0}
 
@@ -390,6 +390,7 @@ def test_custclaim():
         min_confirmations
         )["op_info"]
     feetracker.add_result('custClose', op_info) 
+    import pdb; pdb.set_trace()
     
     op_info = cust_claim(
         cust_acc,


### PR DESCRIPTION
- remove unused `close_scalar`
- move all storage initialization outside of the contract (specifically, `revocation_lock`, `delay_expiry`, and `status`) for consistency. Previously it appeared as though these values were hard coded. This refactor makes the contract initialization more consistent with how `originate` is called in zeekoe.

Note that these changes do not affect the compiled .tz and .json files.