### PR TITLE
add mutual close

### DIFF
--- a/pytezos-tests/pytezos_contract_tester.py
+++ b/pytezos-tests/pytezos_contract_tester.py
@@ -17,6 +17,8 @@ RPC.
 import argparse
 import json
 from pytezos import pytezos, ContractInterface
+from pytezos.michelson.types import MichelsonType
+from pytezos.michelson.parse import michelson_to_micheline
 from pprint import pprint
 import requests
 
@@ -257,6 +259,19 @@ min_confirmations,
 
     return {"status": status, "level": level, "op_info": op_info}
 
+def sign_mutual_close(
+merch_acc,
+contract_id,
+customer_balance, merchant_balance
+):
+    # Merchant pytezos interface
+    merch_py = pytezos.using(key=merch_acc, shell=uri)
+    ty = MichelsonType.match(michelson_to_micheline("pair (pair bls12_381_fr string) (pair address (pair mutez mutez))"))
+    packed = ty.from_python_object((channel_id, 'zkChannels mutual close', contract_id, customer_balance, merchant_balance)).pack(legacy=True).hex()
+    mutual_close_signature = merch_py.key.sign(packed)
+
+    return mutual_close_signature
+
 def mutual_close(
 cust_acc,
 contract_id,
@@ -390,14 +405,50 @@ def test_custclaim():
         min_confirmations
         )["op_info"]
     feetracker.add_result('custClose', op_info) 
-    import pdb; pdb.set_trace()
-    
+
     op_info = cust_claim(
         cust_acc,
         origination_op["contract_id"],
         min_confirmations
         )["op_info"]
-    feetracker.add_result('custClaim', op_info) 
+    feetracker.add_result('custClaim', op_info)
+
+def test_mutualclose():
+    print_header("Scenario test_mutualclose: origination -> add_customer_funding -> mutual_close")
+
+    origination_op = originate(uri,
+        cust_addr, merch_addr,
+        cust_acc,
+        merch_pubkey,
+        channel_id,
+        merch_g2, merch_y2s, merch_x2,
+        cust_funding, merch_funding,
+        min_confirmations, 
+        self_delay
+        )
+    feetracker.add_result('originate', origination_op["op_info"]) 
+
+    op_info = add_customer_funding(
+        cust_acc,
+        origination_op["contract_id"],
+        cust_funding,
+        min_confirmations
+        )["op_info"]
+    feetracker.add_result('addCustFunding', op_info) 
+
+    merch_mutual_close_signature = sign_mutual_close(
+        merch_acc,
+        origination_op["contract_id"],
+        customer_balance, merchant_balance)
+
+    op_info = mutual_close(
+        cust_acc,
+        origination_op["contract_id"],
+        customer_balance, merchant_balance,
+        merch_mutual_close_signature,
+        min_confirmations
+        )["op_info"]
+    feetracker.add_result('mutualClose', op_info) 
 
 def test_dispute():
     print_header("Scenario test_dispute: origination -> add_customer_funding -> expiry -> cust_close -> merch_dispute")
@@ -622,6 +673,7 @@ test_dispute()
 test_merchClaim()
 test_dualfund()
 test_reclaim()
+test_mutualclose()
 
 # Print gas and storage costs of the operations tested.
 feetracker.print_fees()

--- a/pytezos-tests/pytezos_contract_tester.py
+++ b/pytezos-tests/pytezos_contract_tester.py
@@ -266,7 +266,10 @@ customer_balance, merchant_balance
 ):
     # Merchant pytezos interface
     merch_py = pytezos.using(key=merch_acc, shell=uri)
+    # Specify the structure and types of the fields going into the mutual close state.
     ty = MichelsonType.match(michelson_to_micheline("pair (pair bls12_381_fr string) (pair address (pair mutez mutez))"))
+    # create the packed (serialized) version of the mutual close state, corresponding to the types above. 
+    # 'legacy=True' ensures pytezos will always serialize the data as in michelson rather than micheline. 
     packed = ty.from_python_object((channel_id, 'zkChannels mutual close', contract_id, customer_balance, merchant_balance)).pack(legacy=True).hex()
     mutual_close_signature = merch_py.key.sign(packed)
 


### PR DESCRIPTION
adds two functions:
- `sign_mutual_close` - to be called by the merchant to produce the `mutual_close_signature`.
- `mutual_close` - to be called by the customer to call the `mutualClose` entrypoint on the smart contract.

These functions will need to be added to zeekoe in `tezos.rs`. 

`test_mutualclose()` tests the entrypoint on chain.